### PR TITLE
[✦ feat] codex: init agatone96/CosmicPortfolio with universal, cache on, net off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables (no secrets)
+PUBLIC_SITE_URL=
+ANALYTICS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+_codex/
+.DS_Store

--- a/tests/setup.selftest.sh
+++ b/tests/setup.selftest.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 fail(){ echo "◇ FAIL: $1"; exit 1; }
 pass(){ echo "✦ PASS: $1"; }
-R="/workspace/_codex/setup-report.md"; L="/workspace/_codex/setup.log"
-[ -f "$R" ] || fail "setup-report.md missing"
-grep -q "^- Name: " "$R" || fail "env name missing"
-grep -q "Internet access after setup: false" "$R" || fail "internet not Off"
-grep -Eq "/workspace|/workspaces" "$R" || fail "workspace path not recorded"
-[ -f "$L" ] || fail "setup.log missing"
+REPORT_FILE="/workspace/_codex/setup-report.md"
+LOG_FILE="/workspace/_codex/setup.log"
+
+[[ -f "$REPORT_FILE" ]] || fail "setup-report.md missing"
+grep -q "^- Name: " "$REPORT_FILE" || fail "env name missing"
+grep -q "Internet access after setup: false" "$REPORT_FILE" || fail "internet not Off"
+grep -Eq "/workspaces?" "$REPORT_FILE" || fail "workspace path not recorded"
+[[ -f "$LOG_FILE" ]] || fail "setup.log missing"
 pass "all checks passed"

--- a/tests/setup.selftest.sh
+++ b/tests/setup.selftest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+fail(){ echo "◇ FAIL: $1"; exit 1; }
+pass(){ echo "✦ PASS: $1"; }
+R="/workspace/_codex/setup-report.md"; L="/workspace/_codex/setup.log"
+[ -f "$R" ] || fail "setup-report.md missing"
+grep -q "^- Name: " "$R" || fail "env name missing"
+grep -q "Internet access after setup: false" "$R" || fail "internet not Off"
+grep -Eq "/workspace|/workspaces" "$R" || fail "workspace path not recorded"
+[ -f "$L" ] || fail "setup.log missing"
+pass "all checks passed"

--- a/tests/setup.selftest.sh
+++ b/tests/setup.selftest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-fail(){ echo "◇ FAIL: $1"; exit 1; }
+fail(){ echo "◇ FAIL: $1" >&2; exit 1; }
 pass(){ echo "✦ PASS: $1"; }
 REPORT_FILE="/workspace/_codex/setup-report.md"
 LOG_FILE="/workspace/_codex/setup.log"


### PR DESCRIPTION
## Why
- Capture the Codex workspace bootstrap details for the agatone96/CosmicPortfolio environment.
- Ensure environment placeholders and git hygiene align with Codex non-negotiables.

## What
- Added a `.env.example` template and ensured supporting ignore rules cover `.env`, `_codex/`, and macOS artifacts.
- Authored `tests/setup.selftest.sh` to validate required setup artifacts.

## Security
- No secrets committed; environment files contain placeholder values only.

## Tests
- `tests/setup.selftest.sh`

## Performance
- No runtime-impacting changes; additions are configuration and validation helpers only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127730b5608329b56bc3a696c1711b)

## Summary by Sourcery

Initialize the Codex workspace for the CosmicPortfolio environment by adding an environment template, updating ignore rules, and including a validation script

New Features:
- Introduce .env.example template for environment configuration

Enhancements:
- Update .gitignore to exclude .env files, _codex/ artifacts, and macOS system files

Tests:
- Add tests/setup.selftest.sh to validate setup-report.md, setup.log, and configuration settings

Chores:
- Align environment placeholders and git hygiene with Codex standards



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the Codex workspace for agatone96/CosmicPortfolio with an env template, git hygiene, and a setup self-test. Ensures consistent bootstrapping and verifies network is off after setup.

- **New Features**
  - Added .env.example with placeholder variables (no secrets).
  - Updated .gitignore to exclude _codex/ and .DS_Store.
  - Added tests/setup.selftest.sh to validate setup-report.md for env name, "Internet access after setup: false", workspace path, and ensure setup.log exists.

<sup>Written for commit d46bf74f7a55041d653506f37c72687957762483. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



