### PR TITLE
Memoize nebula particle geometry in CosmicCanvas

### DIFF
--- a/src/rendering/CosmicCanvas.jsx
+++ b/src/rendering/CosmicCanvas.jsx
@@ -1,5 +1,5 @@
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useMemo } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Stars, OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
@@ -36,15 +36,22 @@ function NebulaParticles() {
     }
   });
 
-  const particlesGeometry = new THREE.BufferGeometry();
   const particleCount = 5000;
-  const positions = new Float32Array(particleCount * 3);
-  
-  for (let i = 0; i < particleCount * 3; i++) {
-    positions[i] = (Math.random() - 0.5) * 400;
-  }
-  
-  particlesGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  // Memoize buffers so large allocations only happen once per mount.
+  const positions = useMemo(() => {
+    const data = new Float32Array(particleCount * 3);
+
+    for (let i = 0; i < particleCount * 3; i++) {
+      data[i] = (Math.random() - 0.5) * 400;
+    }
+
+    return data;
+  }, []);
+  const particlesGeometry = useMemo(() => {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geometry;
+  }, [positions]);
 
   return (
     <points ref={particlesRef}>


### PR DESCRIPTION
### Motivation

- Reduce per-render allocations in `NebulaParticles` by creating heavy buffers once to improve performance.
- Prevent unnecessary garbage collection spikes caused by reallocating `Float32Array` and `BufferGeometry` on every render.
- Keep runtime behavior identical while making the allocation strategy deterministic and stable.

### Description

- Import `useMemo` and memoize the particle `positions` `Float32Array` using `useMemo` with a stable empty dependency array (`[]`).
- Memoize the `particlesGeometry` (`THREE.BufferGeometry`) and set its `position` attribute from the memoized `positions` to avoid repeated geometry creation.
- Add an inline comment explaining the performance rationale for memoization in `NebulaParticles`.
- No change to rendering logic or material/points setup; `NebulaParticles` and `CosmicCanvas` behavior remains the same at render-time.

### Testing

- No automated tests were run on this change in this rollout.
- No new unit or render tests were added, though adding a render snapshot or a simple mount test for `NebulaParticles` is recommended to guard against regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694edc1eb0d8832992cce84663258e3c)

## Summary by Sourcery

Memoize nebula particle buffers in CosmicCanvas to avoid recreating large geometries and position arrays on every render.

Enhancements:
- Memoize the particle positions Float32Array so it is allocated only once per component mount.
- Memoize the THREE.BufferGeometry for nebula particles and reuse it across renders, wiring it to the memoized positions buffer.
- Document the performance rationale for memoizing nebula particle buffers with an inline comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized nebula particle buffers in CosmicCanvas to stop reallocating Float32Array and BufferGeometry every render, reducing GC spikes and improving frame stability. Visuals and rendering behavior remain unchanged.

- **Refactors**
  - Use useMemo to create the positions Float32Array once per mount (empty deps).
  - Use useMemo to create BufferGeometry and set its position attribute from the memoized buffer.

<sup>Written for commit 128417f7eaaeedecf10c91b2bb4329487b3c7143. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

